### PR TITLE
evemu-event: introduce a FIFO to inject commands

### DIFF
--- a/tools/evemu-event.c
+++ b/tools/evemu-event.c
@@ -26,18 +26,26 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <linux/input.h>
 #include <libevdev/libevdev.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "argz.h"
 
 static struct option opts[] = {
 	{ "type", required_argument, 0, 't'},
 	{ "code", required_argument, 0, 'c'},
 	{ "value", required_argument, 0, 'v'},
 	{ "sync", no_argument, 0, 's'},
-	{ "device", required_argument, 0, 'd'}
+	{ "device", required_argument, 0, 'd'},
+	{ "fifo", optional_argument, 0, 'f'}
 };
+
+static const int MAX_DEV_PATH_LENGTH = 100;
 
 static int parse_arg(const char *arg, long int *value)
 {
@@ -67,9 +75,169 @@ static int parse_code(long int type, const char *arg, long int *value)
 	return parse_arg(arg, value);
 }
 
+// TODO: Add --fifo usage.
 static void usage(void)
 {
-	fprintf(stderr, "Usage: %s [--sync] <device> --type <type> --code <code> --value <value>\n", program_invocation_short_name);
+	fprintf(stderr, "Usage: %s [--sync] <device> --type <type> --code <code> --value <value>\n\n", program_invocation_short_name);
+	fprintf(stderr, "Program also support create a fifo, then write your event to that fifo file.\n"
+					"Usage: %s --fifo=<file_name>\n", program_invocation_short_name);
+}
+
+int ev_from_args(const char* path, long type, long code, long value, int sync)
+{
+	int rc = -1;
+	int fd = -1;
+	struct input_event ev;
+
+	fd = open(path, O_WRONLY);
+	if (fd < 0) {
+		fprintf(stderr, "error: could not open device (%m)\n");
+		goto out;
+	}
+    
+	if (evemu_create_event(&ev, type, code, value)) {
+		fprintf(stderr, "error: failed to create event\n");
+		goto out;
+	}
+
+	if (evemu_play_one(fd, &ev)) {
+		fprintf(stderr, "error: could not play event\n");
+		goto out;
+	}
+
+	if (sync) {
+		if (evemu_create_event(&ev, EV_SYN, SYN_REPORT, 0)) {
+			fprintf(stderr, "error: could not create SYN event\n");
+			goto out;
+		}
+		if (evemu_play_one(fd, &ev)) {
+			fprintf(stderr, "error: could not play SYN event\n");
+			goto out;
+		}
+	}
+
+	rc = 0;
+out:
+	if (fd > -1)
+		close(fd);
+	return rc;
+}
+
+
+/*
+ * Read lines from the fifo @path
+ *
+ *
+ * Each line is in the format:
+ *
+ * - <DEVICE> <TYPE> <CODE> <VALUE> [SYNC]
+ * - WAIT <MILLISECS>
+ * - empty (ignored)
+ *
+ * DEVICE: an absolute name for an input device; if relative,
+ *   /dev/input will be prefixed
+ *
+ * TYPE: type of event (EV_xyz)
+ * 
+ * CODE: code of the event type (eg: SYN_xyz, KEY_xyz, BTN_xyz,
+ *   REL_xyz, ABS_xyz, MSC_xyz, SND_xyz, SW_xyz, LED_xyz, REP_xyz,
+ *   FF_xyz...
+ *
+ * VALUE: numeric value to set (0 to release, 1 to press, etc)
+ * 
+ * SYNC: the event shall carry the sync flag
+ */ 
+int read_fifo(const char* path)
+{
+	int rc = -1;
+	FILE * fp;
+	char * line = NULL;
+	size_t len = 0;
+	ssize_t read;
+
+	mkfifo(path, 0666);
+
+	fp = fopen(path, "r");
+	if (fp == NULL)
+		goto out;
+
+	while (1) {
+		read = getline(&line, &len, fp);		
+		if (read == -1) {
+			/* closed (calling process exited, let's
+			 * reopen and chug along for the next client */
+			fp = fopen(path, "r");
+			continue;
+		}
+			
+		char* result;
+		size_t argz_len;
+		int sync = 0;
+		
+		// Reset rc
+		rc = -1;
+
+		// Replace the last character to '0' before proceed.
+		line[strlen(line)-1] = '\0';
+
+		// Extract the arguments
+		argz_create_sep(line, ' ', &result, &argz_len);
+		int argc = argz_count(result, argz_len);
+		char *argv[argc + 1];
+ 		argz_extract(result, argz_len, argv);
+
+		if (argc == 0)
+			continue;
+		if (strcmp(argv[0], "WAIT") == 0) {
+			float wait_time = atof(argv[1]);
+			struct timespec ts;
+			ts.tv_sec = (int) wait_time;
+			ts.tv_nsec = (wait_time - ts.tv_sec) * 1000000;
+			nanosleep(&ts, NULL);
+			continue;
+		}
+		if (argc != 4 && argc != 5)
+			continue;
+		
+		// DEVICE TYPE CODE VALUE
+		long int type, code, value = LONG_MAX;
+
+		// if the device is just a file name, prepend
+		// /dev/input to it, otherwise it is a path name use
+		// as is
+		char *dev_path;
+		if (strcmp(basename(argv[0]), argv[0]))
+			dev_path = argv[0];
+		else {
+			dev_path = alloca(strlen("/dev/input/")
+					  + strlen(argv[0]) + 1);
+			strcpy(dev_path, "/dev/input/");
+			strcpy(dev_path + strlen("/dev/input/"), argv[0]);
+		}
+
+		if (parse_type(argv[1], &type)) {	// Parse type
+			fprintf(stderr, "error: invalid type argument '%s'\n", argv[1]);
+			continue;
+		}
+	
+		if (parse_code(type, argv[2], &code)) {	// Parse code
+			fprintf(stderr, "error: invalid code argument '%s'\n", argv[2]);
+			continue;
+		}
+
+		// Parse value
+		if (parse_arg(argv[3], &value) || value < INT_MIN || value > INT_MAX) {
+			fprintf(stderr, "error: invalid value argument '%s'\n", argv[3]);
+			continue;
+		}
+
+		if(argc == 5 && strcmp(argv[4], "SYNC") == 0)
+			sync = 1;
+		rc = ev_from_args(dev_path, type, code, value, sync);
+		fprintf(stderr, "sent: %d\n", rc);
+	}
+out:
+	return rc;
 }
 
 int main(int argc, char *argv[])
@@ -80,12 +248,8 @@ int main(int argc, char *argv[])
 	struct input_event ev;
 	int sync = 0;
 	const char *path = NULL;
+	const char *fifo_path = NULL;
 	const char *code_arg = NULL, *type_arg = NULL;
-
-	if (argc < 5) {
-		usage();
-		goto out;
-	}
 
 	while(1) {
 		int option_index = 0;
@@ -114,10 +278,24 @@ int main(int argc, char *argv[])
 			case 's': /* sync */
 				sync = 1;
 				break;
+			case 'f': /* fifo */
+				fifo_path = optarg;
+				break;
 			default:
 				usage();
 				goto out;
 		}
+	}
+
+	/* If fifo is provided, then discard the rest of the arguments. */
+	if(fifo_path != NULL) {
+		rc = read_fifo(fifo_path);
+		goto out;
+	}
+
+	if (argc < 5) {
+		usage();
+		goto out;
 	}
 
 	if (!type_arg || !code_arg || value == LONG_MAX) {
@@ -150,34 +328,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	fd = open(path, O_WRONLY);
-	if (fd < 0) {
-		fprintf(stderr, "error: could not open device (%m)\n");
-		goto out;
-	}
-
-	if (evemu_create_event(&ev, type, code, value)) {
-		fprintf(stderr, "error: failed to create event\n");
-		goto out;
-	}
-
-	if (evemu_play_one(fd, &ev)) {
-		fprintf(stderr, "error: could not play event\n");
-		goto out;
-	}
-
-	if (sync) {
-		if (evemu_create_event(&ev, EV_SYN, SYN_REPORT, 0)) {
-			fprintf(stderr, "error: could not create SYN event\n");
-			goto out;
-		}
-		if (evemu_play_one(fd, &ev)) {
-			fprintf(stderr, "error: could not play SYN event\n");
-			goto out;
-		}
-	}
-
-	rc = 0;
+	rc = ev_from_args(path, type, code, value, sync);
 out:
 	if (fd > -1)
 		close(fd);


### PR DESCRIPTION
This patch adds the --fifo option which puts evemu-event into a mode
where it reads lines from that FIFO and send input events to devices
based on it.

This allows putting it in the background to get commands sent to
devices with ease and performance (when simulating fast mouse
movement); for example, you could make a python script that generates
mice coordinates to draw a circle (as round as your monitor's aspect
is):

  #! /usr/bin/python3
  import math
  import sys
  import time
  t = 0
  td = 0.1
  while True:
      x = 5000 + 3000 * math.cos(2 * 3.1416 * 0.1 * t)
      y = 5000 + 3000 * math.sin(2 * 3.1416 * 0.1 * t)
      print("""\
  event18 EV_ABS ABS_X %s
  event18 EV_ABS ABS_Y %s SYNC
  WAIT %0.3f
  """ % (int(x), int(y), td))
      sys.stdout.flush()
      time.sleep(td / 2)
      t += 0.2

and feeding this into the FIFO of a created device which has a 0-65536
range (this was obtained by querying VMWare's mouse with
event-describe):

  $ cat > mouse.descriptor <<EOF
  # EVEMU 1.3
  # Kernel: 5.1.15-200.fc29.x86_64
  # DMI: dmi:bvnPhoenixTechnologiesLTD:bvr6.00:bd04/13/2018:svnVMware,Inc.:pnVMwareVirtualPlatform:pvrNone:rvnIntelCorporation:rn440BXDesktopReferencePlatform:rvrNone:cvnNoEnclosure:ct1:cvrN/A:
  # Input device name: "VirtualPS/2 VMware VMMouse"
  # Input device ID: bus 0x11 vendor 0x02 product 0x13 version 0x06
  # Supported events:
  #   Event type 0 (EV_SYN)
  #     Event code 0 (SYN_REPORT)
  #     Event code 1 (SYN_CONFIG)
  #     Event code 2 (SYN_MT_REPORT)
  #     Event code 3 (SYN_DROPPED)
  #...
  #     Event code 15 (SYN_MAX)
  #   Event type 1 (EV_KEY)
  #     Event code 272 (BTN_LEFT)
  #     Event code 273 (BTN_RIGHT)
  #     Event code 274 (BTN_MIDDLE)
  #   Event type 3 (EV_ABS)
  #     Event code 0 (ABS_X)
  #       Value        0
  #       Min          0
  #       Max      65535
  #       Fuzz         0
  #       Flat         0
  #       Resolution   0
  #     Event code 1 (ABS_Y)
  #       Value        0
  #       Min          0
  #       Max      65535
  #       Fuzz         0
  #       Flat         0
  #       Resolution   0
  # Properties:
  N: VMWare Mouse
  I: 0011 0002 0013 0006
  P: 00 00 00 00 00 00 00 00
  B: 00 0b 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 07 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 01 00 00 00 00 00 00 00 00
  B: 02 00 00 00 00 00 00 00 00
  B: 03 03 00 00 00 00 00 00 00
  B: 04 00 00 00 00 00 00 00 00
  B: 05 00 00 00 00 00 00 00 00
  B: 11 00 00 00 00 00 00 00 00
  B: 12 00 00 00 00 00 00 00 00
  B: 14 00 00 00 00 00 00 00 00
  B: 15 00 00 00 00 00 00 00 00
  B: 15 00 00 00 00 00 00 00 00
  A: 00 0 65535 0 0 0
  A: 01 0 65535 0 0 0
  EOF
  $ evemu-event --fifo=mouse.fifo
  VMWare Mouse: /dev/input/event18
  $ python circle.py > mouse.fifo

will make our mouse spin around mouse absolute 5000,5000 with a 3000
ratio.

The format of the lines is described in the source in the read_fifo()
function, but it boils down to:

  - <DEVICE> <TYPE> <CODE> <VALUE> [SYNC]
  - WAIT <MILLISECS>
  - empty (ignored)

  DEVICE: an absolute name for an input device; if relative,
    /dev/input will be prefixed

  TYPE: type of event (EV_xyz)

  CODE: code of the event type (eg: SYN_xyz, KEY_xyz, BTN_xyz,
    REL_xyz, ABS_xyz, MSC_xyz, SND_xyz, SW_xyz, LED_xyz, REP_xyz,
    FF_xyz...

  VALUE: numeric value to set (0 to release, 1 to press, etc)

  SYNC: the event shall carry the sync flag

In general, the changes are:

- introduce ev_from_args(), which executes the actions given in the
  command line or in a FIFO line; moves the code in main to use that.

- on --fifo given, calls read_fifo() to start a loop to execute
  commands given on the FIFO.

Co-developed-by: Dic Key Li <dic.key.li@intel.com>
Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>